### PR TITLE
Journey: remove train number from train type if detected

### DIFF
--- a/bin/dbris-m
+++ b/bin/dbris-m
@@ -388,7 +388,7 @@ elsif ( $opt{journey} ) {
 	}
 
 	printf( "%s %s am %s\n\n",
-		$trip->train, $trip->train_no, $trip->day->strftime('%d.%m.%Y') );
+		$trip->type, $trip->train_no, $trip->day->strftime('%d.%m.%Y') );
 
 	for my $stop ( $trip->route ) {
 		if ( $stop == $mark_stop ) {

--- a/lib/Travel/Status/DE/DBRIS/Journey.pm
+++ b/lib/Travel/Status/DE/DBRIS/Journey.pm
@@ -42,6 +42,14 @@ sub new {
 		( $ref->{type}, $ref->{number} ) = split( qr{\s+}, $ref->{train} );
 	}
 
+	# For some trains, the train type also contains the train number like "MEX19161"
+	# If we can detect this, remove the number from the train type
+	if ( $ref->{train_no} and $ref->{type}
+		and $ref->{type} =~ qr{ (?<actualtype> [^\d]+ ) $ref->{train_no} $ }x )
+	{
+		$ref->{type} = $+{actualtype};
+	}
+
 	# The line number seems to be encoded in the trip ID
 	if ( not defined $ref->{number}
 		and $opt{id} =~ m{ [#] ZE [#] (?<line> [^#]+ ) [#] ZB [#] }x )


### PR DESCRIPTION
Moin. I hope this patch is alright to send out of the blue. Checking in with travelynx, i've run across this visual bug with some train operators:
![Screenshot From 2025-05-02 18-48-07](https://github.com/user-attachments/assets/2df061c9-142e-4e2d-8852-59fb3d8f4633)
![image](https://github.com/user-attachments/assets/e60b709e-93e6-496c-b68f-d507744969f5)


Perhaps because the operator code "train type" is three letters long, the API doesn't split it with a space like it does for "RB" or "RE", so the logic that is supposed to separate train type from "number" here doesn't work:
https://github.com/derf/Travel-Status-DE-DBRIS/blob/014cc6bd5551987a94e34dc4a04a0e86cb8e9669/lib/Travel/Status/DE/DBRIS/Journey.pm#L39-L43

This patch adds a check if the detected train type contains the train number extracted from the route and, if so, removes it from the train type.

Thank you for your time and effort in maintaining these projects (: