### PR TITLE
Fix on operator mapping

### DIFF
--- a/share/admin-id-to-operator.json
+++ b/share/admin-id-to-operator.json
@@ -409,7 +409,7 @@
   ],
   "8005SV": [
     "DB",
-    "Rhein-Mosel-Bus Ahrweiler"
+    "DB Regio AG Mitte"
   ],
   "8006000": [
     "DB",


### PR DESCRIPTION
- Resolve "8005SV" to "DB Regio AG Mitte" as this is used for SEV busses of DB Regio AG Mitte.

Closes https://codeberg.org/derf/travelynx/issues/2 I guess
(could reproduce the second point today, as I took a SEV bus by DB Regio AG Mitte)