### PR TITLE
Add name of ICE 8011 "Köln"

### DIFF
--- a/lib/Travel/Status/DE/DBRIS/Formation/Group.pm
+++ b/lib/Travel/Status/DE/DBRIS/Formation/Group.pm
@@ -265,6 +265,7 @@ my %ice_name = (
 	4893 => 'Bodetal',
 	4898 => 'Lahntal',
 	8007 => 'Rheinland',
+	8011 => 'Köln',
 	8019 => 'Düsseldorf',
 	8020 => 'Amsterdam',
 	8022 => 'Waldecker Land',


### PR DESCRIPTION
Tz 8011 was given the name "Köln" today. 
Sources: 
https://www.deutschebahn.com/de/presse/pressestart_zentrales_uebersicht/-Koeln-faehrt-ans-Meer-nach-Ostende--13897298 and the carriage formation of ICE 1110/1111 today